### PR TITLE
SV's can be NULL (shit happens) (fixes RT86217)

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,8 @@
 Revision history for Perl module Clone
 
+0.35 2013-06-30 18:06:54  garu
+  - SV's can be NULL (shit happens) (fixes RT86217) (Tux)
+
 0.34 2012-12-09 14:46:09  garu
   - making some tests optional (fixes RT81774) (GARU)
   - modernizing synopsis (GARU)

--- a/Clone.xs
+++ b/Clone.xs
@@ -121,12 +121,20 @@ sv_clone (SV * ref, HV* hseen, int depth)
 {
   SV *clone = ref;
   SV **seen = NULL;
+  UV visible;
+
+  if (!ref)
+    {
+      TRACEME(("NULL\n"));
+      return NULL;
+    }
+
 #if PERL_REVISION >= 5 && PERL_VERSION > 8
   /* This is a hack for perl 5.9.*, save everything */
   /* until I find out why mg_find is no longer working */
-  UV visible = 1;
+  visible = 1;
 #else
-  UV visible = (SvREFCNT(ref) > 1) || (SvMAGICAL(ref) && mg_find(ref, '<'));
+  visible = (SvREFCNT(ref) > 1) || (SvMAGICAL(ref) && mg_find(ref, '<'));
 #endif
   int magic_ref = 0;
 


### PR DESCRIPTION
Though it is not recommendable,  and VERY hard to do from a pure-perl
api, it isn't that hard for XS to set SV slots to NULL. In some cases
this can be measurable faster than using PL_sv_undef or similar.
