### PR TITLE
Silence warnings

### DIFF
--- a/Clone.xs
+++ b/Clone.xs
@@ -45,7 +45,7 @@ hv_clone (SV * ref, SV * target, HV* hseen, int depth)
   TRACEME(("ref = 0x%x(%d)\n", ref, SvREFCNT(ref)));
 
   hv_iterinit (self);
-  while (next = hv_iternext (self))
+  while ((next = hv_iternext (self)))
     {
       SV *key = hv_iterkeysv (next);
       TRACEME(("clone item %s\n", SvPV_nolen(key) ));
@@ -278,7 +278,7 @@ sv_clone (SV * ref, HV* hseen, int depth)
                  mg->mg_len);
       }
       /* major kludge - why does the vtable for a qr type need to be null? */
-      if ( mg = mg_find(clone, 'r') )
+      if ( (mg = mg_find(clone, 'r')) )
         mg->mg_virtual = (MGVTBL *) NULL;
     }
     /* 2: HASH/ARRAY  - (with 'internal' elements) */


### PR DESCRIPTION
Silence some clang warnings:

```
de -maes -fno-strict-aliasing -fno-stack-protector -O3   -DVERSION=\"0.36\" -DXS_VERSION=\"0.36\"  "-I/Users/jacques/perl/lib/darwin/CORE"   Clone.c
Clone.xs:48:15: warning: using the result of an assignment as a condition without parentheses [-Wparentheses]
  while (next = hv_iternext (self))
         ~~~~~^~~~~~~~~~~~~~~~~~~~
Clone.xs:48:15: note: place parentheses around the assignment to silence this warning
  while (next = hv_iternext (self))
              ^
         (                        )
Clone.xs:48:15: note: use '==' to turn this assignment into an equality comparison
  while (next = hv_iternext (self))
              ^
              ==
Clone.xs:281:15: warning: using the result of an assignment as a condition without parentheses [-Wparentheses]
      if ( mg = mg_find(clone, 'r') )
           ~~~^~~~~~~~~~~~~~~~~~~~~
Clone.xs:281:15: note: place parentheses around the assignment to silence this warning
      if ( mg = mg_find(clone, 'r') )
              ^
           (                       )
Clone.xs:281:15: note: use '==' to turn this assignment into an equality comparison
      if ( mg = mg_find(clone, 'r') )
              ^
              ==
2 warnings generated.
```
