### PR TITLE
use explicit . since it may not be in @INC anymore

### DIFF
--- a/t/04tie.t
+++ b/t/04tie.t
@@ -17,8 +17,8 @@ print "ok 1\n";
 
 my $test = 2;
 
-require 't/dump.pl';
-require 't/tied.pl';
+require './t/dump.pl';
+require './t/tied.pl';
 
 my ($a, @a, %a);
 tie $a, TIED_SCALAR;

--- a/t/dclone.t
+++ b/t/dclone.t
@@ -55,7 +55,7 @@
 # Baseline for first beta release.
 #
 
-require 't/dump.pl';
+require './t/dump.pl';
 
 # use Storable qw(dclone);
 use Clone qw(clone);

--- a/t/tied.pl
+++ b/t/tied.pl
@@ -50,7 +50,7 @@
 # Baseline for first beta release.
 #
 
-require 't/dump.pl';
+require './t/dump.pl';
 
 package TIED_HASH;
 


### PR DESCRIPTION
5.25.7 can be configured to not include '.' in `@INC` by default.