### PR TITLE
Check the CowREFCNT of a COWed PV

### DIFF
--- a/Clone.xs
+++ b/Clone.xs
@@ -176,22 +176,23 @@ sv_clone (SV * ref, HV* hseen, int depth)
 */
 #if PERL_VERSION >= 20 && !defined(PERL_DEBUG_READONLY_COW)
         /* only for simple PVs unblessed */
-        if ( SvIsCOW(ref) && !SvOOK(ref) ) {
+        if ( SvIsCOW(ref) && !SvOOK(ref) && SvLEN(ref) > 0
+            && CowREFCNT(ref) < SV_COW_REFCNT_MAX ) {
           /* cannot use newSVpv_share as this going to use a new PV we do not want to clone it */
           /* create a fresh new PV */
           clone = newSV(0);
           sv_upgrade(clone, SVt_PV);
           SvPOK_on(clone);
           SvIsCOW_on(clone);
+
           /* points the str slot to the COWed one */
           SvPV_set(clone, SvPVX(ref) );
-          /* increase the Cow refcnt if possible (when not using PERL_DEBUG_READONLY_COW)
-          */
-          if ( CowREFCNT(ref) < SV_COW_REFCNT_MAX )
-            CowREFCNT(ref)++;
-          /* preserve cur, len and utf8 flag */
+          CowREFCNT(ref)++;
+
+          /* preserve cur, len, flags and utf8 flag */
           SvCUR_set(clone, SvCUR(ref));
           SvLEN_set(clone, SvLEN(ref));
+          //SvFLAGS(clone) = SvFLAGS(ref);
 
           if (SvUTF8(ref))
             SvUTF8_on(clone);


### PR DESCRIPTION
Resolved #10

Strangely some PV could be cowed with
a COWRefcnt equal 0...

This might hide a more serious problem
somewhere else. But for now the best clone
can do is leave these PVs alone.

Adjust the test as doing \"something" produces
a COWPV with CowREFCNT = 0 which is going
to be lost after cloning.