### PR TITLE
fix: lower MAX_DEPTH to 4000 to prevent SEGV on CPAN smokers (GH #77)

### DIFF
--- a/Clone.xs
+++ b/Clone.xs
@@ -14,15 +14,16 @@
  * nesting level is roughly rdepth/2, using ~450 bytes of stack each.
  *
  * Windows has a 1 MB default thread stack; Cygwin typically 2 MB.
- * Linux/macOS default to 8 MB.  MAX_DEPTH must be low enough that
- * (MAX_DEPTH/2) * ~450 bytes fits within the available stack.
+ * Linux/macOS default to 8 MB but some CPAN smokers and containers
+ * may have 4 MB or less available after Perl/harness overhead.
  *
  * MAX_DEPTH=2000 on Windows/Cygwin -> ~1000 nesting levels -> ~450 KB.
- * MAX_DEPTH=32000 elsewhere -> ~16000 nesting levels -> ~7.2 MB. */
+ * MAX_DEPTH=4000 elsewhere        -> ~2000 nesting levels -> ~900 KB.
+ * (GH #77: 32000 was too aggressive — caused SEGV on CPAN smokers.) */
 #if defined(_WIN32) || defined(__CYGWIN__)
 #define MAX_DEPTH 2000
 #else
-#define MAX_DEPTH 32000
+#define MAX_DEPTH 4000
 #endif
 
 #define CLONE_STORE(x,y)						\

--- a/t/10-deep_recursion.t
+++ b/t/10-deep_recursion.t
@@ -8,15 +8,18 @@ use Config;
 
 # Platform-adaptive depth targets.
 # Windows has a 1 MB default thread stack; Cygwin typically 2 MB;
-# Linux/macOS default to 8 MB.  The depths must be safe for both
-# Perl structure construction AND the Clone XS recursive path.
+# Linux/macOS default to 8 MB but some smokers have less.
+# The depths must be safe for both Clone XS recursion AND Perl's
+# own recursive SvREFCNT_dec when freeing deeply nested structures.
 #
-# Clone.xs uses MAX_DEPTH to switch from recursive to iterative
-# cloning: 2000 on Windows/Cygwin, 32000 elsewhere.
-# The deep target must EXCEED MAX_DEPTH to exercise both paths.
+# Clone.xs uses MAX_DEPTH (in rdepth units) to switch from recursive
+# to iterative cloning: 2000 on Windows/Cygwin, 4000 elsewhere.
+# rdepth increments twice per nesting level (once for AV, once for RV),
+# so the switch happens at roughly MAX_DEPTH/2 nesting levels.
+# The deep target must exceed MAX_DEPTH/2 to exercise both paths.
 my $is_limited_stack = ($^O eq 'MSWin32' || $^O eq 'cygwin');
 
-my $deep_target     = $is_limited_stack ? 4000 : 35000;
+my $deep_target     = $is_limited_stack ? 4000 : 5000;
 
 # Moderate depth used for basic tests (safe everywhere).
 my $moderate_target  = 1000;


### PR DESCRIPTION
MAX_DEPTH=32000 required ~7.2 MB of C stack before switching to iterative mode — too close to the 8 MB default on Linux and over the limit on some CPAN smoker and container environments.  This caused SEGV in t/10-deep_recursion.t on multiple CPAN testers.

Lower MAX_DEPTH to 4000 (~900 KB stack), which is safe on any reasonable system.  The iterative fallback handles deeper structures correctly.

Also lower the test's deep_target from 35000 to 5000: still exceeds MAX_DEPTH/2 (2000 nesting levels) to exercise both recursive and iterative paths, but avoids overflowing Perl's own recursive SvREFCNT_dec during structure cleanup.

Fix: #77