### PR TITLE
fix: don't require MGf_DUP flag for ext magic duplication (GH #76)

### DIFF
--- a/Clone.xs
+++ b/Clone.xs
@@ -474,9 +474,11 @@ sv_clone (SV * ref, HV* hseen, int depth, int rdepth, AV * weakrefs)
 #if defined(MGf_DUP) && defined(sv_magicext)
           /* If the ext magic has a dup callback (e.g. Math::BigInt::GMP),
            * clone it properly via sv_magicext + svt_dup.
-           * Otherwise skip it (e.g. DBI handles have no dup). */
-          if (mg->mg_virtual && mg->mg_virtual->svt_dup
-              && (mg->mg_flags & MGf_DUP))
+           * Otherwise skip it (e.g. DBI handles have no dup).
+           * Note: we check only for svt_dup presence, not MGf_DUP flag,
+           * because some older XS modules (e.g. Math::BigInt::GMP on
+           * Perl 5.22) provide svt_dup without setting MGf_DUP. (GH #76) */
+          if (mg->mg_virtual && mg->mg_virtual->svt_dup)
           {
             MAGIC *new_mg;
             new_mg = sv_magicext(clone, mg->mg_obj,


### PR DESCRIPTION
Older versions of Math::BigInt::GMP provide a valid svt_dup callback but don't set the MGf_DUP flag on their PERL_MAGIC_ext magic. Clone was checking for MGf_DUP before calling svt_dup, causing it to skip the ext magic duplication entirely. The cloned object then had no mpz_t pointer, resulting in "failed to fetch mpz pointer" from bstr().

The presence of svt_dup in the vtable is sufficient — MGf_DUP is a hint for Perl's thread-clone mechanism, not a prerequisite for the dup callback itself. DBI handles (which should not be duped) are still safe because they don't provide svt_dup.

Fix #76