### PR TITLE
fix: suppress DBI STDERR noise in t/13-io-handle.t

### DIFF
--- a/t/13-io-handle.t
+++ b/t/13-io-handle.t
@@ -132,6 +132,7 @@ SKIP: {
 SKIP: {
     eval { require DBI; require DBD::SQLite }
         or skip "DBI + DBD::SQLite required for DBI tests", 4;
+    skip "fork() not available (Windows)", 4 unless _can_fork();
 
     my $result = _run_in_subprocess(sub {
         my $dbh = DBI->connect("dbi:SQLite:dbname=:memory:", "", "",
@@ -177,6 +178,7 @@ SKIP: {
 SKIP: {
     eval { require DBI; require DBD::SQLite }
         or skip "DBI + DBD::SQLite required for sth tests", 2;
+    skip "fork() not available (Windows)", 2 unless _can_fork();
 
     my $result = _run_in_subprocess(sub {
         my $dbh = DBI->connect("dbi:SQLite:dbname=:memory:", "", "",
@@ -206,6 +208,21 @@ SKIP: {
     my %r = map { /^(\w+)=(.*)/ ? ($1 => $2) : () } split /\n/, $result;
     ok($r{clone_ok},       "clone of DBI statement handle does not segfault");
     ok($r{original_works}, "original statement handle still works after clone");
+}
+
+# Check whether fork() is usable.  Strawberry Perl on Windows implements
+# fork() via ithreads emulation which doesn't support pipe+fork reliably,
+# and some builds don't implement it at all.
+sub _can_fork {
+    return 0 if $^O eq 'MSWin32';
+    my $pid = eval { fork() };
+    return 0 unless defined $pid;
+    if ($pid == 0) {
+        require POSIX;
+        POSIX::_exit(0);
+    }
+    waitpid($pid, 0);
+    return 1;
 }
 
 # Run a code block in a forked child process with STDERR suppressed.


### PR DESCRIPTION
Fix #82: Cloned DBI handles lack XS-level magic, causing DBI's
DESTROY to dump pages of SV internals to STDERR. Circular refs
inside the cloned handle tree also cause SEGVs during global
destruction. The previous test 16 ($cloned->prepare) segfaulted
on most platforms.

Fix by running DBI clone tests in forked subprocesses:
- Child redirects STDERR to /dev/null (suppresses all DBI noise)
- Child uses POSIX::_exit(0) to skip destructors (avoids SEGV)
- Child communicates results via pipe as key=value pairs
- Parent relays results to Test::More assertions

Also replace test 16's unsafe $cloned->prepare() call with a safe
Scalar::Util::reftype structural check, and add $sth->finish
before $dbh->disconnect to eliminate the "disconnect invalidates
active statement handle" warning.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
