### PR TITLE
fix: remove spurious warn in t/03-scalar.t

### DIFF
--- a/t/03-scalar.t
+++ b/t/03-scalar.t
@@ -130,7 +130,7 @@ ok( $$a == $$b, 'int check' );
 my $str = 'abcdefg';
 my $qr = qr/$str/;
 my $qc = clone( $qr );
-ok( $qr eq $qc, 'string check' ) or warn "$qr vs $qc";
+ok( $qr eq $qc, 'string check' );
 ok( $str =~ /$qc/, 'regexp check' );
 
 # test for unicode support


### PR DESCRIPTION
The file defines its own ok() sub (line 58) that returns undef
instead of the test result. This caused the `or warn` on line 133
to always fire, printing "(?^:abcdefg) vs (?^:abcdefg)" to STDERR
even when the test passed. Remove the dead diagnostic.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
